### PR TITLE
1.96.0: switch to rspace-parent parent pom & use latest rspace-client-java-model

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,4 @@
 #!groovy
 @Library('rspace-shared') _ 
 // builds rspace-client-java project
-genericJavaLibBuild("emails":"operations@researchspace.com",
- "branch":"${BRANCH_NAME}", "jdk":"OPEN-JDK-11")
+genericJavaLibBuild("emails":"dev@researchspace.com", "branch":"${BRANCH_NAME}")

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.96.0] - 2026-02-19
+- switch to using parent pom from rspace-parent project
+- switch to latest rspace-client-java-model, so the calls work with latest RSpace API
+
 ## [1.95.0] - 2023-12-18
 
 - Compile with java 17

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -4,5 +4,5 @@ before_install:
   - sdk install java 17.0.2-open
   - sdk use java 17.0.2-open
   - java -version
-  - sdk install maven
+  - sdk install maven 3.9.11
   - mvn -v

--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
     <modelVersion>4.0.0</modelVersion>
     
     <artifactId>rspace-client-java</artifactId>
-    <version>1.95.1</version>
+    <version>1.96.0</version>
     <parent>
         <groupId>com.github.rspace-os</groupId>
-        <artifactId>rspace-os-parent</artifactId>
-        <version>0.1.1</version>
+        <artifactId>rspace-parent</artifactId>
+        <version>2.1.4</version>
     </parent>
     
     <repositories>
@@ -30,11 +30,21 @@
         </plugins>
     </build>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>${apache.httpcomponents.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>com.github.rspace-os</groupId>
             <artifactId>rspace-client-java-model</artifactId>
-            <version>1.95.0</version>
+            <version>5b79e00f72</version>
         </dependency>
        
         <dependency>
@@ -58,10 +68,6 @@
             <version>4.4.16</version>
         </dependency>
         <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
         </dependency>
@@ -72,10 +78,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>com.github.rspace-os</groupId>
             <artifactId>rspace-client-java-model</artifactId>
-            <version>5b79e00f72</version>
+            <version>1.99.0</version>
         </dependency>
        
         <dependency>

--- a/src/main/java/com/researchspace/api/client/ApiConnectorImpl.java
+++ b/src/main/java/com/researchspace/api/client/ApiConnectorImpl.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.researchspace.api.clientmodel.*;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.fluent.Content;
 import org.apache.http.client.fluent.Request;


### PR DESCRIPTION
Depends on PR https://github.com/rspace-os/rspace-client-java-model/pull/12